### PR TITLE
List decode fix

### DIFF
--- a/src/Protobuf.elm
+++ b/src/Protobuf.elm
@@ -66,7 +66,7 @@ optional name decoder d =
 -}
 repeated : String -> JD.Decoder a -> JD.Decoder (List a -> b) -> JD.Decoder b
 repeated name decoder d =
-    field (withDefault [] <| JD.list <| JD.field name decoder) d
+    field (withDefault [] <| JD.field name <| JD.list decoder) d
 
 
 {-| Decodes a field.


### PR DESCRIPTION
I believe this is a fix for issue #4. The decode logic said somethink like object is an array when object.element is the array.