### PR TITLE
add proper support for empty messages

### DIFF
--- a/protoc-gen-elm/elm_tests/proto/simple.proto
+++ b/protoc-gen-elm/elm_tests/proto/simple.proto
@@ -6,6 +6,9 @@ import "google/protobuf/wrappers.proto";
 import "dir/other_dir.proto";
 import "other.proto";
 
+message Empty {
+}
+
 message Simple {
   int32 int32_field = 1;
 }

--- a/protoc-gen-elm/elm_tests/tests/Main.elm
+++ b/protoc-gen-elm/elm_tests/tests/Main.elm
@@ -25,8 +25,8 @@ suite =
         [ test "JSON encode" <| \() -> encode T.simpleEncoder msg |> equal msgJson
         , test "JSON decode" <| \() -> decode T.simpleDecoder msgJson |> equal (Ok msg)
         , test "JSON decode extra field" <| \() -> decode T.simpleDecoder msgExtraFieldJson |> equal (Ok msg)
-        , test "JSON encode empty message" <| \() -> encode T.fooEncoder fooDefault |> equal emptyJson
-        , test "JSON decode empty JSON" <| \() -> decode T.simpleDecoder emptyJson |> equal (Ok msgDefault)
+        , test "JSON encode empty message" <| \() -> encode T.emptyEncoder msgEmpty |> equal emptyJson
+        , test "JSON decode empty JSON" <| \() -> decode T.emptyDecoder emptyJson |> equal (Ok msgEmpty)
         , test "JSON encode message with repeated field" <| \() -> encode T.fooEncoder foo |> equal fooJson
         , test "JSON decode message with repeated field" <| \() -> decode T.fooDecoder fooJson |> equal (Ok foo)
         , test "JSON encode message with map field" <| \() -> encode M.mapEncoder map |> equal mapJson
@@ -118,6 +118,10 @@ msgDefault =
     { int32Field = 0
     }
 
+msgEmpty : T.Empty
+msgEmpty =
+    { 
+    }
 
 fooDefault : T.Foo
 fooDefault =

--- a/protoc-gen-elm/elm_tests/tests/Simple.elm
+++ b/protoc-gen-elm/elm_tests/tests/Simple.elm
@@ -68,6 +68,23 @@ colourEncoder v =
         JE.string <| lookup v
 
 
+type alias Empty =
+    {
+    }
+
+
+emptyDecoder : JD.Decoder Empty
+emptyDecoder =
+    JD.lazy <| \_ -> decode Empty
+
+
+emptyEncoder : Empty -> JE.Value
+emptyEncoder v =
+    JE.object <| List.filterMap identity <|
+        [
+        ]
+
+
 type alias Simple =
     { int32Field : Int -- 1
     }

--- a/protoc-gen-elm/message.go
+++ b/protoc-gen-elm/message.go
@@ -16,6 +16,11 @@ func (fg *FileGenerator) GenerateMessageDefinition(prefix string, inMessage *des
 		fg.In()
 
 		leading := "{"
+
+		if len(inMessage.GetField()) == 0 {
+			fg.P(leading)
+		}
+
 		for _, inField := range inMessage.GetField() {
 			if inField.OneofIndex != nil {
 				// Handled in the oneof only.
@@ -129,6 +134,11 @@ func (fg *FileGenerator) GenerateMessageEncoder(prefix string, inMessage *descri
 			fg.In()
 
 			leading := "["
+
+			if len(inMessage.GetField()) == 0 {
+				fg.P(leading)
+			}
+
 			for _, inField := range inMessage.GetField() {
 				if inField.OneofIndex != nil {
 					// Handled in the oneof only.


### PR DESCRIPTION
Protobuf messages without fields compile to broken Elm at the moment. These changes add support for empty messages as suggested at [1].

As I am somewhat new to Elm aswell as to Protobuf, feel to free to suggest improvements. Also the Go tests are failing for me (for current master) and I have no clue why.

[1] https://stackoverflow.com/a/31772973/470509