### PR TITLE
Ignore non-proto3 files

### DIFF
--- a/protoc-gen-elm/main.go
+++ b/protoc-gen-elm/main.go
@@ -117,7 +117,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("Could not process file: %v", err)
 		}
-		resp.File = append(resp.File, outFile)
+		if outFile != nil {
+			resp.File = append(resp.File, outFile)
+		}
 	}
 
 	data, err = proto.Marshal(resp)
@@ -133,7 +135,7 @@ func main() {
 
 func processFile(inFile *descriptor.FileDescriptorProto) (*plugin.CodeGeneratorResponse_File, error) {
 	if inFile.GetSyntax() != "proto3" {
-		return nil, fmt.Errorf("Only proto3 syntax is supported")
+		return nil, nil
 	}
 
 	outFile := &plugin.CodeGeneratorResponse_File{}


### PR DESCRIPTION
In some case a proto3 file includes a proto2 file but will not use the message types in it
directly. Ignoring proto2 files instead of failing allows these cases to run smoothly.