### PR TITLE
Add a "excludeFile" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Then, in your project, add a dependency on the runtime library:
 
 `elm install tiziano88/elm-protobuf`
 
+## Options
+
+Options can be passed to the plugin in the --elm_out value, with the following
+syntax:
+
+`protoc "--elm_out=option=value;option=value1,value2:."`
+
+The valid options are:
+
+- `excludeFile`: A list of files that should be ignored. Usefull to ignore a
+  proto2 file that is a dependency of the compiled file.
+
 ## References
 
 https://developers.google.com/protocol-buffers/

--- a/protoc-gen-elm/main.go
+++ b/protoc-gen-elm/main.go
@@ -102,6 +102,26 @@ func main() {
 		inFile.SourceCodeInfo = nil
 	}
 
+	if parameter := req.GetParameter(); parameter != "" {
+		list := strings.Split(parameter, ";")
+		for _, item := range list {
+			splitted := strings.Split(item, "=")
+			if len(splitted) != 2 {
+				log.Fatalf("Invalid parameter. Expected 'variable=value', got: '%s'", item)
+			}
+			switch splitted[0] {
+			case "excludeFile":
+				fileList := strings.Split(splitted[1], ",")
+				for _, name := range fileList {
+					excludedFiles[name] = true
+				}
+			default:
+				log.Fatalf("Unknow parameter: %s", splitted[0])
+
+			}
+		}
+	}
+
 	log.Printf("Input data: %v", proto.MarshalTextString(req))
 
 	resp := &plugin.CodeGeneratorResponse{}


### PR DESCRIPTION
Solve the case were a proto2 file is in the dependencies and we cannot remove it (and is a less-invasive solution than #19)

Example:

`protoc "--elm_out=excludeFile=google/protobuf/descriptor.proto:."`
