### PR TITLE
Add a useless declaration to every output file.

### DIFF
--- a/protoc-gen-elm/go_tests/testdata/map_entry/expected_output/Map_entry.elm
+++ b/protoc-gen-elm/go_tests/testdata/map_entry/expected_output/Map_entry.elm
@@ -12,6 +12,9 @@ import Json.Encode as JE
 import Dict
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Bar =
     { field : Bool -- 1
     }

--- a/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File1.elm
+++ b/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File1.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias File1Message =
     { field : Bool -- 1
     }

--- a/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File2.elm
+++ b/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File2.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias File2Message =
     { field : Bool -- 1
     }

--- a/protoc-gen-elm/go_tests/testdata/oneof/expected_output/Oneof.elm
+++ b/protoc-gen-elm/go_tests/testdata/oneof/expected_output/Oneof.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Foo =
     { firstOneof : FirstOneof
     , secondOneof : SecondOneof

--- a/protoc-gen-elm/go_tests/testdata/repeated/expected_output/Repeated.elm
+++ b/protoc-gen-elm/go_tests/testdata/repeated/expected_output/Repeated.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type Enum
     = EnumValueDefault -- 0
     | EnumValue1 -- 1

--- a/protoc-gen-elm/go_tests/testdata/well_known_types/expected_output/Well_known_types.elm
+++ b/protoc-gen-elm/go_tests/testdata/well_known_types/expected_output/Well_known_types.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Message =
     { doubleValueField : Maybe Float -- 1
     }

--- a/protoc-gen-elm/main.go
+++ b/protoc-gen-elm/main.go
@@ -214,6 +214,10 @@ func processFile(inFile *descriptor.FileDescriptorProto) (*plugin.CodeGeneratorR
 		fg.P("import %s exposing (..)", fullModuleName)
 	}
 
+	fg.P("")
+	fg.P("")
+	fg.P("uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42")
+
 	var err error
 
 	// Top-level enums.

--- a/tests/Dir/Other_dir.elm
+++ b/tests/Dir/Other_dir.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias OtherDir =
     { stringField : String -- 1
     }

--- a/tests/Fuzzer.elm
+++ b/tests/Fuzzer.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Fuzz =
     { stringField : String -- 1
     , int32Field : Int -- 2

--- a/tests/Integers.elm
+++ b/tests/Integers.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias ThirtyTwo =
     { int32Field : Int -- 1
     , uint32Field : Int -- 2

--- a/tests/Keywords.elm
+++ b/tests/Keywords.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Keywords =
     { module_ : Int -- 1
     , exposing_ : Int -- 2

--- a/tests/Map.elm
+++ b/tests/Map.elm
@@ -12,6 +12,9 @@ import Json.Encode as JE
 import Dict
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias MapValue =
     { field : Bool -- 1
     }

--- a/tests/Other.elm
+++ b/tests/Other.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Other =
     { stringField : String -- 1
     }

--- a/tests/Recursive.elm
+++ b/tests/Recursive.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Rec =
     { int32Field : Int -- 1
     , stringField : String -- 4

--- a/tests/Simple.elm
+++ b/tests/Simple.elm
@@ -13,6 +13,9 @@ import Dir.Other_dir exposing (..)
 import Other exposing (..)
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type Colour
     = ColourUnspecified -- 0
     | Red -- 1

--- a/tests/Wrappers.elm
+++ b/tests/Wrappers.elm
@@ -11,6 +11,9 @@ import Json.Decode as JD
 import Json.Encode as JE
 
 
+uselessDeclarationToPreventErrorDueToEmptyOutputFile = 42
+
+
 type alias Wrappers =
     { int32ValueField : Maybe Int -- 1
     , int64ValueField : Maybe Int -- 2


### PR DESCRIPTION
Without this declaration in place, we may end up source files that are
not buildable by Elm. Elm requires that all source files contain at
least one declaration.

An example of a source file that contains no declarations is part of
Google APIs:

https://github.com/googleapis/googleapis/blob/master/google/api/annotations.proto

This file is transitively dragged in by Bazel's remote execution
defintions:

https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/execution/v2/remote_execution.proto