### PR TITLE
Add support for recursively defined message structures.

### DIFF
--- a/protoc-gen-elm/go_tests/testdata/map_entry/expected_output/Map_entry.elm
+++ b/protoc-gen-elm/go_tests/testdata/map_entry/expected_output/Map_entry.elm
@@ -15,6 +15,7 @@ import Dict
 type alias Bar =
     { field : Bool -- 1
     }
+type BarMessage = BarMessage Bar
 
 
 barDecoder : JD.Decoder Bar
@@ -31,44 +32,46 @@ barEncoder v =
 
 
 type alias Foo =
-    { stringToBars : Dict.Dict String Bar -- 8
+    { stringToBars : Dict.Dict String BarMessage -- 8
     , stringToStrings : Dict.Dict String String -- 7
     }
+type FooMessage = FooMessage Foo
 
 
 fooDecoder : JD.Decoder Foo
 fooDecoder =
     JD.lazy <| \_ -> decode Foo
-        |> mapEntries "stringToBars" barDecoder
+        |> mapEntries "stringToBars" (JD.map BarMessage barDecoder)
         |> mapEntries "stringToStrings" JD.string
 
 
 fooEncoder : Foo -> JE.Value
 fooEncoder v =
     JE.object <| List.filterMap identity <|
-        [ (mapEntriesFieldEncoder "stringToBars" barEncoder v.stringToBars)
+        [ (mapEntriesFieldEncoder "stringToBars" (\(BarMessage f) -> barEncoder f) v.stringToBars)
         , (mapEntriesFieldEncoder "stringToStrings" JE.string v.stringToStrings)
         ]
 
 
 type alias Foo_StringToBarsEntry =
     { key : String -- 1
-    , value : Maybe Bar -- 2
+    , value : Maybe BarMessage -- 2
     }
+type Foo_StringToBarsEntryMessage = Foo_StringToBarsEntryMessage Foo_StringToBarsEntry
 
 
 foo_StringToBarsEntryDecoder : JD.Decoder Foo_StringToBarsEntry
 foo_StringToBarsEntryDecoder =
     JD.lazy <| \_ -> decode Foo_StringToBarsEntry
         |> required "key" JD.string ""
-        |> optional "value" barDecoder
+        |> optional "value" (JD.map BarMessage barDecoder)
 
 
 foo_StringToBarsEntryEncoder : Foo_StringToBarsEntry -> JE.Value
 foo_StringToBarsEntryEncoder v =
     JE.object <| List.filterMap identity <|
         [ (requiredFieldEncoder "key" JE.string "" v.key)
-        , (optionalEncoder "value" barEncoder v.value)
+        , (optionalEncoder "value" (\(BarMessage f) -> barEncoder f) v.value)
         ]
 
 
@@ -76,6 +79,7 @@ type alias Foo_StringToStringsEntry =
     { key : String -- 1
     , value : String -- 2
     }
+type Foo_StringToStringsEntryMessage = Foo_StringToStringsEntryMessage Foo_StringToStringsEntry
 
 
 foo_StringToStringsEntryDecoder : JD.Decoder Foo_StringToStringsEntry

--- a/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File1.elm
+++ b/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File1.elm
@@ -14,6 +14,7 @@ import Json.Encode as JE
 type alias File1Message =
     { field : Bool -- 1
     }
+type File1MessageMessage = File1MessageMessage File1Message
 
 
 file1MessageDecoder : JD.Decoder File1Message

--- a/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File2.elm
+++ b/protoc-gen-elm/go_tests/testdata/multiple_files/expected_output/File2.elm
@@ -14,6 +14,7 @@ import Json.Encode as JE
 type alias File2Message =
     { field : Bool -- 1
     }
+type File2MessageMessage = File2MessageMessage File2Message
 
 
 file2MessageDecoder : JD.Decoder File2Message

--- a/protoc-gen-elm/go_tests/testdata/oneof/expected_output/Oneof.elm
+++ b/protoc-gen-elm/go_tests/testdata/oneof/expected_output/Oneof.elm
@@ -67,6 +67,7 @@ secondOneofEncoder v =
             Just ( "boolField", JE.bool x )
         OtherStringField x ->
             Just ( "otherStringField", JE.string x )
+type FooMessage = FooMessage Foo
 
 
 fooDecoder : JD.Decoder Foo

--- a/protoc-gen-elm/go_tests/testdata/repeated/expected_output/Repeated.elm
+++ b/protoc-gen-elm/go_tests/testdata/repeated/expected_output/Repeated.elm
@@ -69,6 +69,7 @@ enumEncoder v =
 type alias SubMessage =
     { int32Field : Int -- 1
     }
+type SubMessageMessage = SubMessageMessage SubMessage
 
 
 subMessageDecoder : JD.Decoder SubMessage
@@ -100,12 +101,13 @@ type alias Foo =
     , boolField : Bool -- 13
     , stringField : String -- 14
     , enumField : Enum -- 15
-    , subMessage : Maybe SubMessage -- 16
+    , subMessage : Maybe SubMessageMessage -- 16
     , repeatedInt64Field : List Int -- 17
     , repeatedEnumField : List Enum -- 18
-    , nestedMessageField : Maybe Foo_NestedMessage -- 19
+    , nestedMessageField : Maybe Foo_NestedMessageMessage -- 19
     , nestedEnumField : Foo_NestedEnum -- 20
     }
+type FooMessage = FooMessage Foo
 
 
 type Foo_NestedEnum
@@ -130,10 +132,10 @@ fooDecoder =
         |> required "boolField" JD.bool False
         |> required "stringField" JD.string ""
         |> required "enumField" enumDecoder enumDefault
-        |> optional "subMessage" subMessageDecoder
+        |> optional "subMessage" (JD.map SubMessageMessage subMessageDecoder)
         |> repeated "repeatedInt64Field" intDecoder
         |> repeated "repeatedEnumField" enumDecoder
-        |> optional "nestedMessageField" foo_NestedMessageDecoder
+        |> optional "nestedMessageField" (JD.map Foo_NestedMessageMessage foo_NestedMessageDecoder)
         |> required "nestedEnumField" foo_NestedEnumDecoder foo_NestedEnumDefault
 
 
@@ -173,10 +175,10 @@ fooEncoder v =
         , (requiredFieldEncoder "boolField" JE.bool False v.boolField)
         , (requiredFieldEncoder "stringField" JE.string "" v.stringField)
         , (requiredFieldEncoder "enumField" enumEncoder enumDefault v.enumField)
-        , (optionalEncoder "subMessage" subMessageEncoder v.subMessage)
+        , (optionalEncoder "subMessage" (\(SubMessageMessage f) -> subMessageEncoder f) v.subMessage)
         , (repeatedFieldEncoder "repeatedInt64Field" numericStringEncoder v.repeatedInt64Field)
         , (repeatedFieldEncoder "repeatedEnumField" enumEncoder v.repeatedEnumField)
-        , (optionalEncoder "nestedMessageField" foo_NestedMessageEncoder v.nestedMessageField)
+        , (optionalEncoder "nestedMessageField" (\(Foo_NestedMessageMessage f) -> foo_NestedMessageEncoder f) v.nestedMessageField)
         , (requiredFieldEncoder "nestedEnumField" foo_NestedEnumEncoder foo_NestedEnumDefault v.nestedEnumField)
         ]
 
@@ -196,6 +198,7 @@ foo_NestedEnumEncoder v =
 type alias Foo_NestedMessage =
     { int32Field : Int -- 1
     }
+type Foo_NestedMessageMessage = Foo_NestedMessageMessage Foo_NestedMessage
 
 
 foo_NestedMessageDecoder : JD.Decoder Foo_NestedMessage
@@ -214,6 +217,7 @@ foo_NestedMessageEncoder v =
 type alias Foo_NestedMessage_NestedNestedMessage =
     { int32Field : Int -- 1
     }
+type Foo_NestedMessage_NestedNestedMessageMessage = Foo_NestedMessage_NestedNestedMessageMessage Foo_NestedMessage_NestedNestedMessage
 
 
 foo_NestedMessage_NestedNestedMessageDecoder : JD.Decoder Foo_NestedMessage_NestedNestedMessage
@@ -245,8 +249,9 @@ type alias FooRepeated =
     , boolField : List Bool -- 13
     , stringField : List String -- 14
     , enumField : List Enum -- 15
-    , subMessage : List SubMessage -- 16
+    , subMessage : List SubMessageMessage -- 16
     }
+type FooRepeatedMessage = FooRepeatedMessage FooRepeated
 
 
 fooRepeatedDecoder : JD.Decoder FooRepeated
@@ -267,7 +272,7 @@ fooRepeatedDecoder =
         |> repeated "boolField" JD.bool
         |> repeated "stringField" JD.string
         |> repeated "enumField" enumDecoder
-        |> repeated "subMessage" subMessageDecoder
+        |> repeated "subMessage" (JD.map SubMessageMessage subMessageDecoder)
 
 
 fooRepeatedEncoder : FooRepeated -> JE.Value
@@ -288,5 +293,5 @@ fooRepeatedEncoder v =
         , (repeatedFieldEncoder "boolField" JE.bool v.boolField)
         , (repeatedFieldEncoder "stringField" JE.string v.stringField)
         , (repeatedFieldEncoder "enumField" enumEncoder v.enumField)
-        , (repeatedFieldEncoder "subMessage" subMessageEncoder v.subMessage)
+        , (repeatedFieldEncoder "subMessage" (\(SubMessageMessage f) -> subMessageEncoder f) v.subMessage)
         ]

--- a/protoc-gen-elm/go_tests/testdata/well_known_types/expected_output/Well_known_types.elm
+++ b/protoc-gen-elm/go_tests/testdata/well_known_types/expected_output/Well_known_types.elm
@@ -14,6 +14,7 @@ import Json.Encode as JE
 type alias Message =
     { doubleValueField : Maybe Float -- 1
     }
+type MessageMessage = MessageMessage Message
 
 
 messageDecoder : JD.Decoder Message

--- a/tests/Dir/Other_dir.elm
+++ b/tests/Dir/Other_dir.elm
@@ -14,6 +14,7 @@ import Json.Encode as JE
 type alias OtherDir =
     { stringField : String -- 1
     }
+type OtherDirMessage = OtherDirMessage OtherDir
 
 
 otherDirDecoder : JD.Decoder OtherDir

--- a/tests/Fuzzer.elm
+++ b/tests/Fuzzer.elm
@@ -18,6 +18,7 @@ type alias Fuzz =
     , int32ValueField : Maybe Int -- 4
     , timestampField : Maybe Timestamp -- 5
     }
+type FuzzMessage = FuzzMessage Fuzz
 
 
 fuzzDecoder : JD.Decoder Fuzz

--- a/tests/Integers.elm
+++ b/tests/Integers.elm
@@ -18,6 +18,7 @@ type alias ThirtyTwo =
     , fixed32Field : Int -- 4
     , sfixed32Field : Int -- 5
     }
+type ThirtyTwoMessage = ThirtyTwoMessage ThirtyTwo
 
 
 thirtyTwoDecoder : JD.Decoder ThirtyTwo
@@ -48,6 +49,7 @@ type alias SixtyFour =
     , fixed64Field : Int -- 4
     , sfixed64Field : Int -- 5
     }
+type SixtyFourMessage = SixtyFourMessage SixtyFour
 
 
 sixtyFourDecoder : JD.Decoder SixtyFour

--- a/tests/Keywords.elm
+++ b/tests/Keywords.elm
@@ -27,6 +27,7 @@ type alias Keywords =
     , port_ : Int -- 13
     , as_ : Int -- 14
     }
+type KeywordsMessage = KeywordsMessage Keywords
 
 
 keywordsDecoder : JD.Decoder Keywords

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,5 +1,6 @@
 module Main exposing (assertEncodeDecode, decode, emptyJson, encode, foo, fooDefault, fooJson, fuzz, genFuzz, json32numbers, json32strings, json64numbers, json64strings, map, mapJson, msg, msg32, msg64, msgDefault, msgEmpty, msgExtraFieldJson, msgJson, nullJson, oo1Set, oo1SetJson, oo2Set, oo2SetJson, rec1, rec2, recDefault, recJson1, recJson2, suite, timestampFoo, timestampJson, wrappersEmpty, wrappersJsonEmpty, wrappersJsonNull, wrappersJsonSet, wrappersJsonZero, wrappersSet, wrappersZero, wrongTypeJson)
 
+import Dir.Other_dir as OD
 import Expect exposing (..)
 import Fuzz exposing (..)
 import Fuzzer as F
@@ -9,6 +10,7 @@ import Json.Decode as JD
 import Json.Encode as JE
 import Keywords as K
 import Map as M
+import Other as O
 import Protobuf exposing (..)
 import Recursive as R
 import Result
@@ -185,14 +187,10 @@ emptyJson =
 foo : T.Foo
 foo =
     { s =
-        Just
-            { int32Field = 11
-            }
+        Just <| T.SimpleMessage { int32Field = 11 }
     , ss =
-        [ { int32Field = 111
-          }
-        , { int32Field = 222
-          }
+        [ T.SimpleMessage { int32Field = 111 }
+        , T.SimpleMessage { int32Field = 222 }
         ]
     , colour = T.Red
     , colours =
@@ -209,13 +207,9 @@ foo =
     , bytesField = []
     , stringValueField = Nothing
     , otherField =
-        Just
-            { stringField = "xxx"
-            }
+        Just <| O.OtherMessage { stringField = "xxx" }
     , otherDirField =
-        Just
-            { stringField = "yyy"
-            }
+        Just <| OD.OtherDirMessage { stringField = "yyy" }
     , timestampField = Nothing
     }
 
@@ -320,11 +314,12 @@ rec1 : R.Rec
 rec1 =
     { int32Field = 0
     , r =
-        R.RecField
-            { int32Field = 0
-            , r = R.RUnspecified
-            , stringField = ""
-            }
+        R.RecField <|
+            R.RecMessage
+                { int32Field = 0
+                , r = R.RUnspecified
+                , stringField = ""
+                }
     , stringField = ""
     }
 
@@ -344,16 +339,18 @@ rec2 : R.Rec
 rec2 =
     { int32Field = 0
     , r =
-        R.RecField
-            { int32Field = 0
-            , r =
-                R.RecField
-                    { int32Field = 0
-                    , r = R.RUnspecified
-                    , stringField = ""
-                    }
-            , stringField = ""
-            }
+        R.RecField <|
+            R.RecMessage
+                { int32Field = 0
+                , r =
+                    R.RecField <|
+                        R.RecMessage
+                            { int32Field = 0
+                            , r = R.RUnspecified
+                            , stringField = ""
+                            }
+                , stringField = ""
+                }
     , stringField = ""
     }
 
@@ -478,8 +475,8 @@ wrappersSet =
 map : M.MessageWithMaps
 map =
     { stringToMessages = Dict.fromList 
-        [ ( "foo" ,  { field = True } ),
-        ( "bar" ,  { field = False } )
+        [ ( "foo" ,  M.MapValueMessage { field = True } ),
+        ( "bar" ,  M.MapValueMessage { field = False } )
         ],
         stringToStrings = Dict.fromList
         [

--- a/tests/Map.elm
+++ b/tests/Map.elm
@@ -15,6 +15,7 @@ import Dict
 type alias MapValue =
     { field : Bool -- 1
     }
+type MapValueMessage = MapValueMessage MapValue
 
 
 mapValueDecoder : JD.Decoder MapValue
@@ -31,44 +32,46 @@ mapValueEncoder v =
 
 
 type alias MessageWithMaps =
-    { stringToMessages : Dict.Dict String MapValue -- 8
+    { stringToMessages : Dict.Dict String MapValueMessage -- 8
     , stringToStrings : Dict.Dict String String -- 7
     }
+type MessageWithMapsMessage = MessageWithMapsMessage MessageWithMaps
 
 
 messageWithMapsDecoder : JD.Decoder MessageWithMaps
 messageWithMapsDecoder =
     JD.lazy <| \_ -> decode MessageWithMaps
-        |> mapEntries "stringToMessages" mapValueDecoder
+        |> mapEntries "stringToMessages" (JD.map MapValueMessage mapValueDecoder)
         |> mapEntries "stringToStrings" JD.string
 
 
 messageWithMapsEncoder : MessageWithMaps -> JE.Value
 messageWithMapsEncoder v =
     JE.object <| List.filterMap identity <|
-        [ (mapEntriesFieldEncoder "stringToMessages" mapValueEncoder v.stringToMessages)
+        [ (mapEntriesFieldEncoder "stringToMessages" (\(MapValueMessage f) -> mapValueEncoder f) v.stringToMessages)
         , (mapEntriesFieldEncoder "stringToStrings" JE.string v.stringToStrings)
         ]
 
 
 type alias MessageWithMaps_StringToMessagesEntry =
     { key : String -- 1
-    , value : Maybe MapValue -- 2
+    , value : Maybe MapValueMessage -- 2
     }
+type MessageWithMaps_StringToMessagesEntryMessage = MessageWithMaps_StringToMessagesEntryMessage MessageWithMaps_StringToMessagesEntry
 
 
 messageWithMaps_StringToMessagesEntryDecoder : JD.Decoder MessageWithMaps_StringToMessagesEntry
 messageWithMaps_StringToMessagesEntryDecoder =
     JD.lazy <| \_ -> decode MessageWithMaps_StringToMessagesEntry
         |> required "key" JD.string ""
-        |> optional "value" mapValueDecoder
+        |> optional "value" (JD.map MapValueMessage mapValueDecoder)
 
 
 messageWithMaps_StringToMessagesEntryEncoder : MessageWithMaps_StringToMessagesEntry -> JE.Value
 messageWithMaps_StringToMessagesEntryEncoder v =
     JE.object <| List.filterMap identity <|
         [ (requiredFieldEncoder "key" JE.string "" v.key)
-        , (optionalEncoder "value" mapValueEncoder v.value)
+        , (optionalEncoder "value" (\(MapValueMessage f) -> mapValueEncoder f) v.value)
         ]
 
 
@@ -76,6 +79,7 @@ type alias MessageWithMaps_StringToStringsEntry =
     { key : String -- 1
     , value : String -- 2
     }
+type MessageWithMaps_StringToStringsEntryMessage = MessageWithMaps_StringToStringsEntryMessage MessageWithMaps_StringToStringsEntry
 
 
 messageWithMaps_StringToStringsEntryDecoder : JD.Decoder MessageWithMaps_StringToStringsEntry

--- a/tests/Other.elm
+++ b/tests/Other.elm
@@ -14,6 +14,7 @@ import Json.Encode as JE
 type alias Other =
     { stringField : String -- 1
     }
+type OtherMessage = OtherMessage Other
 
 
 otherDecoder : JD.Decoder Other

--- a/tests/Recursive.elm
+++ b/tests/Recursive.elm
@@ -20,13 +20,13 @@ type alias Rec =
 
 type R
     = RUnspecified
-    | RecField Rec
+    | RecField RecMessage
 
 
 rDecoder : JD.Decoder R
 rDecoder =
     JD.lazy <| \_ -> JD.oneOf
-        [ JD.map RecField (JD.field "recField" recDecoder)
+        [ JD.map RecField (JD.field "recField" (JD.map RecMessage recDecoder))
         , JD.succeed RUnspecified
         ]
 
@@ -37,7 +37,8 @@ rEncoder v =
         RUnspecified ->
             Nothing
         RecField x ->
-            Just ( "recField", recEncoder x )
+            Just ( "recField", (\(RecMessage f) -> recEncoder f) x )
+type RecMessage = RecMessage Rec
 
 
 recDecoder : JD.Decoder Rec

--- a/tests/Wrappers.elm
+++ b/tests/Wrappers.elm
@@ -22,6 +22,7 @@ type alias Wrappers =
     , stringValueField : Maybe String -- 8
     , bytesValueField : Maybe Bytes -- 9
     }
+type WrappersMessage = WrappersMessage Wrappers
 
 
 wrappersDecoder : JD.Decoder Wrappers


### PR DESCRIPTION
I'm trying to use this library in combination with a relatively complex
protocol, namely the remote execution protocol of the Bazel build sytem:

https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/execution/v2/remote_execution.proto

Some of the dependencies of this protocol contain recursively defined
messages. These currently cause the compiler to emit Elm code that isn't
valid, due to recursive alias types.

Solve this by adding a "%sMessage" custom type for every message. This
causes the recursion to be broken. Let all nested messages use this type
and fix up the encode/decode functions to properly destruct/pack
messages into the custom type.