### PR TITLE
Remove hardcoded list of tests from update_expected_output.

### DIFF
--- a/update_expected_output
+++ b/update_expected_output
@@ -6,7 +6,6 @@ readonly ROOT="$(dirname "$0")"
 
 cd "$ROOT"
 
-cp -r ./protoc-gen-elm/go_tests/testdata/multiple_files/{actual_output/*,expected_output}
-cp -r ./protoc-gen-elm/go_tests/testdata/oneof/{actual_output/*,expected_output}
-cp -r ./protoc-gen-elm/go_tests/testdata/repeated/{actual_output/*,expected_output}
-cp -r ./protoc-gen-elm/go_tests/testdata/well_known_types/{actual_output/*,expected_output}
+for directory in protoc-gen-elm/go_tests/testdata/*; do
+  cp -r ${directory}/{actual_output/*,expected_output}
+done


### PR DESCRIPTION
The map_entry test is currently missing from this list, meaning the
script fails to sync some of the files. Instead of extending that list,
simply iterate over all of the directories that are present.